### PR TITLE
chore: pin GitHub Actions to a full length commit SHA

### DIFF
--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - name: create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Summary

This PR fixes the SHA versions for GitHub Actions. I would appreciate it if the reviewer could merge it after the review is complete.

## Changes

### Updated workflow files:

* `.github/workflows/tagged_release.yaml`

## Security

By pinning the referenced actions to specific SHAs, this change helps prevent potential supply chain attacks.
